### PR TITLE
Fix: Update test assertion for Xtruct.byte_thing

### DIFF
--- a/src/test/java/com/github/decster/ThriftAstBuilderTest.java
+++ b/src/test/java/com/github/decster/ThriftAstBuilderTest.java
@@ -276,6 +276,6 @@ public class ThriftAstBuilderTest {
 
         Optional<FieldNode> byteField = xtruct.getFields().stream().filter(f -> "byte_thing".equals(f.getName())).findFirst();
         assertTrue(byteField.isPresent(), "Xtruct.byte_thing field should exist");
-        assertEquals("byte", byteField.get().getType().getName(), "Xtruct.byte_thing type should be byte");
+        assertEquals("i8", byteField.get().getType().getName(), "Xtruct.byte_thing type should be byte");
     }
 }


### PR DESCRIPTION
The Thrift definition for Xtruct.byte_thing uses the type 'i8'. The test ThriftAstBuilderTest.testParsingThriftTestFile was asserting that the parsed type should be 'byte'.

Thrift documentation indicates that 'i8' and 'byte' are synonyms, with 'i8' being the encouraged form. This commit updates the test assertion to expect 'i8' to align with the Thrift definition and current best practices.

All tests pass after this change.