### PR TITLE
feat: Implement incremental compilation for Thrift plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A minimal setup in your pom.xml would look like:
 <plugin>
     <groupId>io.github.decster</groupId>
     <artifactId>thrift-java-maven-plugin</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.2-SNAPSHOT</version>
     <executions>
         <execution>
             <goals>
@@ -56,7 +56,7 @@ This will search for Thrift files in `src/main/thrift` and generate Java code in
         <plugin>
             <groupId>io.github.decster</groupId>
             <artifactId>thrift-java-maven-plugin</artifactId>
-            <version>0.1.1</version>
+            <version>0.1.2-SNAPSHOT</version>
             <executions>
                 <execution>
                     <goals>
@@ -144,7 +144,7 @@ mvn clean package
 Once built, you can run the compiler from the command line:
 
 ```bash
-java -jar target/thrift-java-maven-plugin-0.1.1-standalone.jar src/test/resources/include_tests/BackendService.thrift   -o genoutput
+java -jar target/thrift-java-maven-plugin-0.1.2-SNAPSHOT-standalone.jar src/test/resources/include_tests/BackendService.thrift   -o genoutput
 ```
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.decster</groupId>
     <artifactId>thrift-java-maven-plugin</artifactId>
-    <version>0.1.1</version>
+    <version>0.1.2-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>Thrift Java Compiler Maven Plugin</name>
@@ -14,7 +14,7 @@
         Maven plugin for generating Java code from Thrift files,
         pure java implementation without thrift binary dependency.
     </description>
-    <url>https://github.com/decster/thrift-java-compiler</url>
+    <url>https://github.com/decster/thrift-java-maven-plugin</url>
 
     <licenses>
         <license>
@@ -32,9 +32,9 @@
     </developers>
 
     <scm>
-        <connection>scm:git:git://github.com/decster/thrift-java-compiler.git</connection>
-        <developerConnection>scm:git:ssh://github.com:decster/thrift-java-compiler.git</developerConnection>
-        <url>https://github.com/decster/thrift-java-compiler</url>
+        <connection>scm:git:git://github.com/decster/thrift-java-maven-plugin.git</connection>
+        <developerConnection>scm:git:ssh://github.com:decster/thrift-java-maven-plugin.git</developerConnection>
+        <url>https://github.com/decster/thrift-java-maven-plugin</url>
     </scm>
 
     <properties>

--- a/src/main/java/io/github/decster/ThriftCompiler.java
+++ b/src/main/java/io/github/decster/ThriftCompiler.java
@@ -56,6 +56,16 @@ public class ThriftCompiler {
     return program;
   }
 
+  public static int compileThriftFiles(
+          List<String> filesToParse,
+          String outputDirectory,
+          List<String> includeDirs,
+          String genOptionsStr,
+          Function<String, Void> logger)
+          throws IOException {
+    return compileThriftFiles(filesToParse, outputDirectory, includeDirs, genOptionsStr, logger, false);
+  }
+
   /**
    * @return total number of files generated
    */
@@ -64,7 +74,8 @@ public class ThriftCompiler {
       String outputDirectory,
       List<String> includeDirs,
       String genOptionsStr,
-      Function<String, Void> logger)
+      Function<String, Void> logger,
+      boolean incrementalCompilation)
       throws IOException {
     if (logger==null) {
       logger = s -> {
@@ -121,7 +132,7 @@ public class ThriftCompiler {
       TProgram program = recursiveParse(filePath, null, new HashSet<>(), allIncludeDirs);
 
       // Generate code for this file
-      JavaGenerator generator = new JavaGenerator(program, outputDirectory, javaGenOptions);
+      JavaGenerator generator = new JavaGenerator(program, outputDirectory, javaGenOptions, incrementalCompilation);
       int filesGenerated = generator.generateAndWriteToFile();
 
       // Output a single line per file with the number of files generated
@@ -162,7 +173,8 @@ public class ThriftCompiler {
           s -> {
             System.out.println(s);
             return null;
-          });
+          },
+          false); // Pass false for incrementalCompilation in main, or add CLI arg
 
     } catch (ParameterException e) {
       System.err.println("Error parsing command-line arguments: " + e.getMessage());

--- a/src/main/java/io/github/decster/maven/ThriftCompilerMojo.java
+++ b/src/main/java/io/github/decster/maven/ThriftCompilerMojo.java
@@ -57,6 +57,12 @@ public class ThriftCompilerMojo extends AbstractMojo {
     private boolean skip;
 
     /**
+     * Flag to enable incremental compilation.
+     */
+    @Parameter(defaultValue = "false", property = "thrift.incrementalCompilation")
+    private boolean incrementalCompilation;
+
+    /**
      * Maven project.
      */
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
@@ -94,8 +100,8 @@ public class ThriftCompilerMojo extends AbstractMojo {
 
         try {
             getLog().info("Compiling " + thriftFiles.size() + " Thrift files to " + outputDirectory);
-            int numFiles = ThriftCompiler.compileThriftFiles(thriftFiles, outputDirectory.getAbsolutePath(), includeDirPaths, generatorOptions, null);
-            getLog().info("Thrift compilation completed, generated files: " + numFiles);
+            int numFiles = ThriftCompiler.compileThriftFiles(thriftFiles, outputDirectory.getAbsolutePath(), includeDirPaths, generatorOptions, null, incrementalCompilation);
+            getLog().info("Thrift compilation completed, incremental: "+ incrementalCompilation+ " generatedFiles: " + numFiles);
 
             // Add the output directory to the project's sources
             project.addCompileSourceRoot(outputDirectory.getAbsolutePath());


### PR DESCRIPTION
This change introduces incremental compilation to the `thrift-java-maven-plugin`.

A new boolean configuration parameter `incrementalCompilation` (defaulting to `false`) has been added to the `ThriftCompilerMojo`. When set to `true`, the plugin will now check if a generated Java file has actually changed before overwriting it.

The core logic involves:
- Passing the `incrementalCompilation` flag through `ThriftCompiler` to `JavaGenerator`.
- In `JavaGenerator`, if the flag is true and an output file already exists, its content is read and compared with the newly generated content.
- The file is only overwritten if its content differs or if it's a new file.

A new test suite, `ThriftCompilerMojoTest`, has been added. This test uses `MavenCli` to run a dedicated test Maven project (`incremental_test_project`) located in `src/test/resources`. The test verifies:
1. Initial compilation generates files.
2. Subsequent compilation without Thrift changes does NOT update file timestamps (no recompile).
3. Compilation after a Thrift file modification DOES update file timestamps (recompile).

The main project's `pom.xml` has been updated to include `maven-core` and `maven-embedder` as test dependencies to support `MavenCli` usage in tests.